### PR TITLE
Allow interactive input for house size

### DIFF
--- a/house_price_predictor.py
+++ b/house_price_predictor.py
@@ -19,8 +19,12 @@ model.fit(X, y)
 x_line = np.linspace(X.min(), X.max(), 100).reshape(-1, 1)
 y_line = model.predict(x_line)
 
-# 💡 Predict the price of a house with 2,000 sqft
-sqft_example = 2000
+# 💡 Ask the user for the house size and predict the price
+try:
+    sqft_example = float(input("Enter the house size in sqft: "))
+except ValueError:
+    print("Invalid input. Using default value of 2000 sqft.")
+    sqft_example = 2000
 predicted_price = model.predict([[sqft_example]])[0]
 
 # 🎨 Plot the results
@@ -28,7 +32,7 @@ plt.figure(figsize=(10, 6))
 plt.scatter(X, y, color='skyblue', alpha=0.4, label="Actual Data")
 plt.plot(x_line, y_line, color='red', label="Best Fit Line")
 plt.scatter(sqft_example, predicted_price, color='green', s=100,
-            label=f"Predicted (2000 sqft): £{predicted_price:,.0f}")
+            label=f"Predicted ({sqft_example:.0f} sqft): £{predicted_price:,.0f}")
 
 plt.title("House Price Prediction Based on Size")
 plt.xlabel("Size (sqft)")
@@ -44,4 +48,4 @@ intercept = model.intercept_
 
 print(f"Slope: {slope:.2f}")
 print(f"Intercept: {intercept:.2f}")
-print(f"📈 Predicted price for a 2000 sqft house: £{predicted_price:,.2f}")
+print(f"📈 Predicted price for a {sqft_example:.0f} sqft house: £{predicted_price:,.2f}")


### PR DESCRIPTION
## Summary
- make the example square footage configurable via user input

## Testing
- `python -m py_compile house_price_predictor.py`

------
https://chatgpt.com/codex/tasks/task_e_6851a74f35cc832aa3793335125ba5bb